### PR TITLE
Set catkin_package dependency of BZip2 for rosbag and rosbag_storage

### DIFF
--- a/tools/rosbag/CMakeLists.txt
+++ b/tools/rosbag/CMakeLists.txt
@@ -22,7 +22,9 @@ set(PROJECT_INSTALLSPACE_LIBRARIES ros::rosbag)
 catkin_package(
   LIBRARIES rosbag
   INCLUDE_DIRS include
-  CATKIN_DEPENDS rosbag_storage rosconsole roscpp std_srvs topic_tools xmlrpcpp)
+  CATKIN_DEPENDS rosbag_storage rosconsole roscpp std_srvs topic_tools xmlrpcpp
+  DEPENDS "Boost COMPONENTS date_time regex program_options filesystem" BZip2
+)
 
 add_library(rosbag
   src/player.cpp

--- a/tools/rosbag_storage/CMakeLists.txt
+++ b/tools/rosbag_storage/CMakeLists.txt
@@ -19,7 +19,7 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES rosbag_storage
   CATKIN_DEPENDS pluginlib roslz4
-  DEPENDS console_bridge "Boost COMPONENTS date_time filesystem program_options regex"
+  DEPENDS console_bridge "Boost COMPONENTS date_time filesystem program_options regex" BZip2
 )
 
 # Support large bags (>2GB) on 32-bit systems


### PR DESCRIPTION
BZip2 is not set as a dependency in the `catkin_package` call. This means that any package that depends on `rosbag` and `rosbag_storage` would have to have another call for the transitive dependency of BZip2.

This pull request fixes that.